### PR TITLE
added new optional param `classInstance` to `Serializer` and `Deserializer` helper classes

### DIFF
--- a/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -26,20 +26,32 @@ import language.existentials
 /** Wraps a Kafka `Deserializer`, provided for
   * convenience, since it can be implicitly fetched
   * from the context.
+  *
+  * @param className is the full package path to the Kafka `Deserializer`
+  *
+  * @param classType is the actual [[Class]] for [[className]]
+  *
+  * @param constructor creates an instance of [[classType]].
+  *        This is defaulted with a `Deserializer.Constructor[A]` function that creates a
+  *        new instance using an assumed empty constructor.
+  *        Supplying this parameter allows for manual provision of the `Deserializer`.
   */
 final case class Deserializer[A](
   className: String,
   classType: Class[_ <: KafkaDeserializer[A]],
-  classInstance: Deserializer.ClassInstanceProvider[A] = (d: Deserializer[A]) => d.classType.newInstance()) {
+  constructor: Deserializer.Constructor[A] = (d: Deserializer[A]) => d.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaDeserializer[A] =
-    classInstance(this)
+    constructor(this)
 }
 
 object Deserializer {
 
-  type ClassInstanceProvider[A] = (Deserializer[A]) => KafkaDeserializer[A]
+  /** Alias for the function that provides an instance of
+    * the Kafka `Deserializer`.
+    */
+  type Constructor[A] = (Deserializer[A]) => KafkaDeserializer[A]
 
   implicit val forStrings: Deserializer[String] =
     Deserializer(

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -29,14 +29,18 @@ import language.existentials
   */
 final case class Deserializer[A](
   className: String,
-  classType: Class[_ <: KafkaDeserializer[A]]) {
+  classType: Class[_ <: KafkaDeserializer[A]],
+  classInstance: Deserializer.ClassInstanceProvider[A] = (d: Deserializer[A]) => d.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaDeserializer[A] =
-  classType.newInstance()
+    classInstance(this)
 }
 
 object Deserializer {
+
+  type ClassInstanceProvider[A] = (Deserializer[A]) => KafkaDeserializer[A]
+
   implicit val forStrings: Deserializer[String] =
     Deserializer(
       className = "org.apache.kafka.common.serialization.StringDeserializer",

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
@@ -26,20 +26,32 @@ import language.existentials
 /** Wraps a Kafka `Serializer`, provided for
   * convenience, since it can be implicitly fetched
   * from the context.
+  *
+  * @param className is the full package path to the Kafka `Serializer`
+  *
+  * @param classType is the actual [[Class]] for [[className]]
+  *
+  * @param constructor creates an instance of [[classType]].
+  *        This is defaulted with a `Serializer.Constructor[A]` function that creates a
+  *        new instance using an assumed empty constructor.
+  *        Supplying this parameter allows for manual provision of the `Serializer`.
   */
 final case class Serializer[A](
   className: String,
   classType: Class[_ <: KafkaSerializer[A]],
-  classInstance: Serializer.ClassInstanceProvider[A] = (s: Serializer[A]) => s.classType.newInstance()) {
+  constructor: Serializer.Constructor[A] = (s: Serializer[A]) => s.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaSerializer[A] =
-    classInstance(this)
+    constructor(this)
 }
 
 object Serializer {
 
-  type ClassInstanceProvider[A] = (Serializer[A]) => KafkaSerializer[A]
+  /** Alias for the function that provides an instance of
+    * the Kafka `Serializer`.
+    */
+  type Constructor[A] = (Serializer[A]) => KafkaSerializer[A]
 
   implicit val forStrings: Serializer[String] =
     Serializer(

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
@@ -29,14 +29,18 @@ import language.existentials
   */
 final case class Serializer[A](
   className: String,
-  classType: Class[_ <: KafkaSerializer[A]]) {
+  classType: Class[_ <: KafkaSerializer[A]],
+  classInstance: Serializer.ClassInstanceProvider[A] = (s: Serializer[A]) => s.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaSerializer[A] =
-    classType.newInstance()
+    classInstance(this)
 }
 
 object Serializer {
+
+  type ClassInstanceProvider[A] = (Serializer[A]) => KafkaSerializer[A]
+
   implicit val forStrings: Serializer[String] =
     Serializer(
       className = "org.apache.kafka.common.serialization.StringSerializer",

--- a/kafka-0.8.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.8.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -23,20 +23,32 @@ import language.existentials
 /** Wraps a Kafka `Decoder`, provided for
   * convenience, since it can be implicitly fetched
   * from the context.
+  *
+  * @param className is the full package path to the Kafka `Decoder`
+  *
+  * @param classType is the actual [[Class]] for [[className]]
+  *
+  * @param constructor creates an instance of [[classType]].
+  *        This is defaulted with a `Deserializer.Constructor[A]` function that creates a
+  *        new instance using an assumed empty or nullable constructor.
+  *        Supplying this parameter allows for manual provision of the `Decoder`.
   */
 final case class Deserializer[A](
   className: String,
   classType: Class[_ <: KafkaDecoder[A]],
-  classInstance: Deserializer.ClassInstanceProvider[A] = Deserializer.reflectCreate[A] _) {
+  constructor: Deserializer.Constructor[A] = Deserializer.reflectCreate[A] _) {
 
   /** Creates a new instance. */
   def create(): KafkaDecoder[A] =
-    classInstance(this)
+    constructor(this)
 }
 
 object Deserializer {
 
-  type ClassInstanceProvider[A] = (Deserializer[A]) => KafkaDecoder[A]
+  /** Alias for the function that provides an instance of
+    * the Kafka `Decoder`.
+    */
+  type Constructor[A] = (Deserializer[A]) => KafkaDecoder[A]
 
   private def reflectCreate[A](d: Deserializer[A]): KafkaDecoder[A] = {
     val constructor = d.classType.getDeclaredConstructors()(0)

--- a/kafka-0.8.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.8.x/src/main/scala/monix/kafka/Serializer.scala
@@ -24,20 +24,32 @@ import language.existentials
 /** Wraps a Kafka `Serializer`, provided for
   * convenience, since it can be implicitly fetched
   * from the context.
+  *
+  * @param className is the full package path to the Kafka `Serializer`
+  *
+  * @param classType is the actual [[Class]] for [[className]]
+  *
+  * @param constructor creates an instance of [[classType]].
+  *        This is defaulted with a `Serializer.Constructor[A]` function that creates a
+  *        new instance using an assumed empty constructor.
+  *        Supplying this parameter allows for manual provision of the `Serializer`.
   */
 final case class Serializer[A](
   className: String,
   classType: Class[_ <: KafkaSerializer[A]],
-  classInstance: Serializer.ClassInstanceProvider[A] = (s: Serializer[A]) => s.classType.newInstance()) {
+  constructor: Serializer.Constructor[A] = (s: Serializer[A]) => s.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaSerializer[A] =
-    classInstance(this)
+    constructor(this)
 }
 
 object Serializer {
 
-  type ClassInstanceProvider[A] = (Serializer[A]) => KafkaSerializer[A]
+  /** Alias for the function that provides an instance of
+    * the Kafka `Serializer`.
+    */
+  type Constructor[A] = (Serializer[A]) => KafkaSerializer[A]
 
   implicit val forStrings: Serializer[String] =
     Serializer(

--- a/kafka-0.8.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.8.x/src/main/scala/monix/kafka/Serializer.scala
@@ -27,14 +27,18 @@ import language.existentials
   */
 final case class Serializer[A](
   className: String,
-  classType: Class[_ <: KafkaSerializer[A]]) {
+  classType: Class[_ <: KafkaSerializer[A]],
+  classInstance: Serializer.ClassInstanceProvider[A] = (s: Serializer[A]) => s.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaSerializer[A] =
-    classType.newInstance()
+    classInstance(this)
 }
 
 object Serializer {
+
+  type ClassInstanceProvider[A] = (Serializer[A]) => KafkaSerializer[A]
+
   implicit val forStrings: Serializer[String] =
     Serializer(
       className = "org.apache.kafka.common.serialization.StringSerializer",

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -24,20 +24,32 @@ import language.existentials
 /** Wraps a Kafka `Deserializer`, provided for
   * convenience, since it can be implicitly fetched
   * from the context.
+  *
+  * @param className is the full package path to the Kafka `Deserializer`
+  *
+  * @param classType is the actual [[Class]] for [[className]]
+  *
+  * @param constructor creates an instance of [[classType]].
+  *        This is defaulted with a `Deserializer.Constructor[A]` function that creates a
+  *        new instance using an assumed empty constructor.
+  *        Supplying this parameter allows for manual provision of the `Deserializer`.
   */
 final case class Deserializer[A](
   className: String,
   classType: Class[_ <: KafkaDeserializer[A]],
-  classInstance: Deserializer.ClassInstanceProvider[A] = (d: Deserializer[A]) => d.classType.newInstance()) {
+  constructor: Deserializer.Constructor[A] = (d: Deserializer[A]) => d.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaDeserializer[A] =
-    classInstance(this)
+    constructor(this)
 }
 
 object Deserializer {
 
-  type ClassInstanceProvider[A] = (Deserializer[A]) => KafkaDeserializer[A]
+  /** Alias for the function that provides an instance of
+    * the Kafka `Deserializer`.
+    */
+  type Constructor[A] = (Deserializer[A]) => KafkaDeserializer[A]
 
   implicit val forStrings: Deserializer[String] =
     Deserializer(

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -27,14 +27,18 @@ import language.existentials
   */
 final case class Deserializer[A](
   className: String,
-  classType: Class[_ <: KafkaDeserializer[A]]) {
+  classType: Class[_ <: KafkaDeserializer[A]],
+  classInstance: Deserializer.ClassInstanceProvider[A] = (d: Deserializer[A]) => d.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaDeserializer[A] =
-  classType.newInstance()
+    classInstance(this)
 }
 
 object Deserializer {
+
+  type ClassInstanceProvider[A] = (Deserializer[A]) => KafkaDeserializer[A]
+
   implicit val forStrings: Deserializer[String] =
     Deserializer(
       className = "org.apache.kafka.common.serialization.StringDeserializer",

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
@@ -24,20 +24,32 @@ import language.existentials
 /** Wraps a Kafka `Serializer`, provided for
   * convenience, since it can be implicitly fetched
   * from the context.
+  *
+  * @param className is the full package path to the Kafka `Serializer`
+  *
+  * @param classType is the actual [[Class]] for [[className]]
+  *
+  * @param constructor creates an instance of [[classType]].
+  *        This is defaulted with a `Serializer.Constructor[A]` function that creates a
+  *        new instance using an assumed empty constructor.
+  *        Supplying this parameter allows for manual provision of the `Serializer`.
   */
 final case class Serializer[A](
   className: String,
   classType: Class[_ <: KafkaSerializer[A]],
-  classInstance: Serializer.ClassInstanceProvider[A] = (s: Serializer[A]) => s.classType.newInstance()) {
+  constructor: Serializer.Constructor[A] = (s: Serializer[A]) => s.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaSerializer[A] =
-    classInstance(this)
+    constructor(this)
 }
 
 object Serializer {
 
-  type ClassInstanceProvider[A] = (Serializer[A]) => KafkaSerializer[A]
+  /** Alias for the function that provides an instance of
+    * the Kafka `Serializer`.
+    */
+  type Constructor[A] = (Serializer[A]) => KafkaSerializer[A]
 
   implicit val forStrings: Serializer[String] =
     Serializer(

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
@@ -27,14 +27,18 @@ import language.existentials
   */
 final case class Serializer[A](
   className: String,
-  classType: Class[_ <: KafkaSerializer[A]]) {
+  classType: Class[_ <: KafkaSerializer[A]],
+  classInstance: Serializer.ClassInstanceProvider[A] = (s: Serializer[A]) => s.classType.newInstance()) {
 
   /** Creates a new instance. */
   def create(): KafkaSerializer[A] =
-    classType.newInstance()
+    classInstance(this)
 }
 
 object Serializer {
+
+  type ClassInstanceProvider[A] = (Serializer[A]) => KafkaSerializer[A]
+
   implicit val forStrings: Serializer[String] =
     Serializer(
       className = "org.apache.kafka.common.serialization.StringSerializer",


### PR DESCRIPTION
These are defaulted to perform the normal behaviour: reflective construction of the specified classes. The param can then be set so that one can specify (provide) logic that defines how an instance of the class should be constructed. The primary use case for this was special serializers that take constructor parameters.

Addresses Issue #4