### PR TITLE
Adds Embedded Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,8 @@ In SBT:
 libraryDependencies += "io.monix" %% "monix-kafka-1x" % "0.16"
 ```
 
-Or in case you're interested in running the tests of this project,
-first download the Kafka server, version `1.0.x` from their 
-[download page](https://kafka.apache.org/downloads.html), then as the
-[quick start](https://kafka.apache.org/documentation.html#quickstart)
-section says, open a terminal window and first start Zookeeper:
-
-```bash
-bin/zookeeper-server-start.sh config/zookeeper.properties
-```
-
-Then start Kafka:
-
-```bash
-bin/kafka-server-start.sh config/server.properties
-```
-
-Create the topic we need for our tests:
-
-```bash
-bin/kafka-topics.sh --create --zookeeper localhost:2181 \
-  --replication-factor 1 --partitions 1 \
-  --topic monix-kafka-tests
-```
-
-And run the tests:
+Or in case you're interested in running the tests of this project, it
+now supports embedded kafka for integration testing. You can simply run:
 
 ```bash
 sbt kafka1x/test
@@ -61,31 +38,8 @@ In SBT:
 libraryDependencies += "io.monix" %% "monix-kafka-11" % "0.16"
 ```
 
-Or in case you're interested in running the tests of this project,
-first download the Kafka server, version `0.11.x` from their 
-[download page](https://kafka.apache.org/downloads.html), then as the
-[quick start](https://kafka.apache.org/documentation.html#quickstart)
-section says, open a terminal window and first start Zookeeper:
-
-```bash
-bin/zookeeper-server-start.sh config/zookeeper.properties
-```
-
-Then start Kafka:
-
-```bash
-bin/kafka-server-start.sh config/server.properties
-```
-
-Create the topic we need for our tests:
-
-```bash
-bin/kafka-topics.sh --create --zookeeper localhost:2181 \
-  --replication-factor 1 --partitions 1 \
-  --topic monix-kafka-tests
-```
-
-And run the tests:
+Or in case you're interested in running the tests of this project, it
+now supports embedded kafka for integration testing. You can simply run:
 
 ```bash
 sbt kafka11/test
@@ -99,37 +53,16 @@ In SBT:
 libraryDependencies += "io.monix" %% "monix-kafka-10" % "0.16"
 ```
 
-Or in case you're interested in running the tests of this project,
-first download the Kafka server, version `0.10.x` from their 
-[download page](https://kafka.apache.org/downloads.html), then as the
-[quick start](https://kafka.apache.org/documentation.html#quickstart)
-section says, open a terminal window and first start Zookeeper:
-
-```bash
-bin/zookeeper-server-start.sh config/zookeeper.properties
-```
-
-Then start Kafka:
-
-```bash
-bin/kafka-server-start.sh config/server.properties
-```
-
-Create the topic we need for our tests:
-
-```bash
-bin/kafka-topics.sh --create --zookeeper localhost:2181 \
-  --replication-factor 1 --partitions 1 \
-  --topic monix-kafka-tests
-```
-
-And run the tests:
+Or in case you're interested in running the tests of this project, it
+now supports embedded kafka for integration testing. You can simply run:
 
 ```bash
 sbt kafka10/test
 ```
 
 ## Getting Started with Kafka 0.9.x
+
+Please note that `EmbeddedKafka` is not supported for Kafka `0.9.x`
 
 In SBT:
 

--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,8 @@ lazy val kafka1x = project.in(file("kafka-1.0.x"))
   .settings(
     name := "monix-kafka-1x",
     libraryDependencies ++= Seq(
-      "org.apache.kafka" %  "kafka-clients" % "1.0.0" exclude("org.slf4j","slf4j-log4j12") exclude("log4j", "log4j")
+      "org.apache.kafka" %  "kafka-clients" % "1.0.0" exclude("org.slf4j","slf4j-log4j12") exclude("log4j", "log4j"),
+      "net.manub"        %% "scalatest-embedded-kafka" % "1.0.0" % "test" exclude ("log4j", "log4j")
     )
   )
 
@@ -210,7 +211,8 @@ lazy val kafka11 = project.in(file("kafka-0.11.x"))
   .settings(
     name := "monix-kafka-11",
     libraryDependencies ++= Seq(
-      "org.apache.kafka" %  "kafka-clients" % "0.11.0.1" exclude("org.slf4j","slf4j-log4j12") exclude("log4j", "log4j")
+      "org.apache.kafka" %  "kafka-clients" % "0.11.0.1" exclude("org.slf4j","slf4j-log4j12") exclude("log4j", "log4j"),
+      "net.manub"        %% "scalatest-embedded-kafka" % "1.0.0" % "test" exclude ("log4j", "log4j")
     )
   )
 
@@ -221,7 +223,8 @@ lazy val kafka10 = project.in(file("kafka-0.10.x"))
   .settings(
     name := "monix-kafka-10",
     libraryDependencies ++= Seq(
-      "org.apache.kafka" %  "kafka-clients" % "0.10.2.1" exclude("org.slf4j","slf4j-log4j12") exclude("log4j", "log4j")
+      "org.apache.kafka" %  "kafka-clients" % "0.10.2.1" exclude("org.slf4j","slf4j-log4j12") exclude("log4j", "log4j"),
+      "net.manub"        %% "scalatest-embedded-kafka" % "0.13.1" % "test" exclude ("log4j", "log4j")
     )
   )
 

--- a/kafka-0.10.x/src/test/scala/monix/kafka/KafkaTestKit.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/KafkaTestKit.scala
@@ -1,0 +1,20 @@
+package monix.kafka
+
+import net.manub.embeddedkafka.EmbeddedKafka
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+
+trait KafkaTestKit extends BeforeAndAfterAll { self: Suite =>
+
+  override def beforeAll(): Unit = {
+    EmbeddedKafka.start()
+    sys.addShutdownHook {
+      EmbeddedKafka.stop()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    EmbeddedKafka.stop()
+  }
+
+}

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -27,16 +27,16 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 
-class MonixKafkaTest extends FunSuite {
+class MonixKafkaTest extends FunSuite with KafkaTestKit {
   val topicName = "monix-kafka-tests"
 
   val producerCfg: KafkaProducerConfig = KafkaProducerConfig.default.copy(
-    bootstrapServers = List("127.0.0.1:9092"),
+    bootstrapServers = List("127.0.0.1:6001"),
     clientId = "monix-kafka-10-producer-test"
   )
 
   val consumerCfg: KafkaConsumerConfig = KafkaConsumerConfig.default.copy(
-    bootstrapServers = List("127.0.0.1:9092"),
+    bootstrapServers = List("127.0.0.1:6001"),
     groupId = "kafka-tests",
     clientId = "monix-kafka-10-consumer-test",
     autoOffsetReset = AutoOffsetReset.Earliest

--- a/kafka-0.11.x/src/test/scala/monix/kafka/KafkaTestKit.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/KafkaTestKit.scala
@@ -1,0 +1,19 @@
+package monix.kafka
+
+import net.manub.embeddedkafka.EmbeddedKafka
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait KafkaTestKit extends BeforeAndAfterAll { self: Suite =>
+
+  override def beforeAll(): Unit = {
+    EmbeddedKafka.start()
+    sys.addShutdownHook {
+      EmbeddedKafka.stop()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    EmbeddedKafka.stop()
+  }
+
+}

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -27,16 +27,16 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 
-class MonixKafkaTest extends FunSuite {
+class MonixKafkaTest extends FunSuite with KafkaTestKit {
   val topicName = "monix-kafka-tests"
 
   val producerCfg = KafkaProducerConfig.default.copy(
-    bootstrapServers = List("127.0.0.1:9092"),
+    bootstrapServers = List("127.0.0.1:6001"),
     clientId = "monix-kafka-11-producer-test"
   )
 
   val consumerCfg = KafkaConsumerConfig.default.copy(
-    bootstrapServers = List("127.0.0.1:9092"),
+    bootstrapServers = List("127.0.0.1:6001"),
     groupId = "kafka-tests",
     clientId = "monix-kafka-11-consumer-test",
     autoOffsetReset = AutoOffsetReset.Earliest

--- a/kafka-1.0.x/src/test/scala/monix/kafka/KafkaTestKit.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/KafkaTestKit.scala
@@ -1,0 +1,19 @@
+package monix.kafka
+
+import net.manub.embeddedkafka.EmbeddedKafka
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait KafkaTestKit extends BeforeAndAfterAll { self: Suite =>
+
+  override def beforeAll(): Unit = {
+    EmbeddedKafka.start()
+    sys.addShutdownHook {
+      EmbeddedKafka.stop()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    EmbeddedKafka.stop()
+  }
+
+}

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -27,16 +27,16 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 
-class MonixKafkaTest extends FunSuite {
+class MonixKafkaTest extends FunSuite with KafkaTestKit {
   val topicName = "monix-kafka-tests"
 
   val producerCfg = KafkaProducerConfig.default.copy(
-    bootstrapServers = List("127.0.0.1:9092"),
+    bootstrapServers = List("127.0.0.1:6001"),
     clientId = "monix-kafka-1-0-producer-test"
   )
 
   val consumerCfg = KafkaConsumerConfig.default.copy(
-    bootstrapServers = List("127.0.0.1:9092"),
+    bootstrapServers = List("127.0.0.1:6001"),
     groupId = "kafka-tests",
     clientId = "monix-kafka-1-0-consumer-test",
     autoOffsetReset = AutoOffsetReset.Earliest


### PR DESCRIPTION
Adds [Embedded Kafka](https://github.com/manub/scalatest-embedded-kafka) for integrated tests.

Does not support `Kafka9`.