### PR TITLE
Fixed typos, updated license year

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ All code must be licensed under the Apache 2.0 license and all files
 must include the following copyright header:
 
 ```
-Copyright (c) 2014-$today.year by its authors. Some rights reserved.
-See the project homepage at: https://github.com/monixio/monix
+Copyright (c) 2014-2019 by its authors. Some rights reserved.
+See the project homepage at: https://github.com/monix/monix-kafka
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ libraryDependencies += "io.monix" %% "monix-kafka-1x" % "1.0.0-RC2"
 For `kafka` versions higher than `1.0.x` also add a dependency override:
 
 ```scala
-dependencyOverrides += "org.apache.kafka" %% "kafka" % "2.1.0"
+dependencyOverrides += "org.apache.kafka" % "kafka" % "2.1.0"
 ```
 
 Or in case you're interested in running the tests of this project, it
@@ -243,4 +243,4 @@ The current maintainers (people who can merge pull requests) are:
 ## License
 
 All code in this repository is licensed under the Apache License,
-Version 2.0.  See [LICENSE.txt](./LICENSE.txt).
+Version 2.0.  See [LICENSE.txt](./LICENSE).

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val sharedSettings = Seq(
   scalacOptions in doc ++=
     Opts.doc.title(s"Monix"),
   scalacOptions in doc ++=
-    Opts.doc.sourceUrl(s"https://github.com/monixio/monix-kafka/tree/v${version.value}€{FILE_PATH}.scala"),
+    Opts.doc.sourceUrl(s"https://github.com/monix/monix-kafka/tree/v${version.value}€{FILE_PATH}.scala"),
   scalacOptions in doc ++=
     Seq("-doc-root-content", file("docs/rootdoc.txt").getAbsolutePath),
   scalacOptions in doc ++=
@@ -119,7 +119,7 @@ lazy val sharedSettings = Seq(
   licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/monix/monix-kafka")),
   headerLicense := Some(HeaderLicense.Custom(
-    """|Copyright (c) 2014-2018 by The Monix Project Developers.
+    """|Copyright (c) 2014-2019 by The Monix Project Developers.
        |
        |Licensed under the Apache License, Version 2.0 (the "License");
        |you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/test/scala/monix/kafka/package.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/package.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/test/scala/monix/kafka/package.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/package.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/test/scala/monix/kafka/package.scala
+++ b/kafka-0.9.x/src/test/scala/monix/kafka/package.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 by The Monix Project Developers.
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/test/scala/monix/kafka/package.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/package.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2018 by its authors. Some rights reserved.
- * See the project homepage at: https://github.com/monixio/monix-kafka
+ * Copyright (c) 2014-2019 by its authors. Some rights reserved.
+ * See the project homepage at: https://github.com/monix/monix-kafka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,6 +1,6 @@
 #
-# Copyright (c) 2014-2018 by its authors. Some rights reserved.
-# See the project homepage at: https://github.com/monixio/monix-kafka
+# Copyright (c) 2014-2019 by its authors. Some rights reserved.
+# See the project homepage at: https://github.com/monix/monix-kafka
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
While working on the previous PR I wanted to fix some annoying typos :smile: 

* Fixed typos in README and CONTRIBUTING docs.
* Updated copyright year from 2018 to 2019 in headers
* Changed project homepage from `https://github.com/monixio/monix-kafka` to actual `https://github.com/monix/monix-kafka`