### PR TITLE
Producer send fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,6 @@ https://github.com/sherwinschiu
 
 Mikhail Chugunkov
 https://github.com/poslegm
+
+Vasiliy Efimov
+https://github.com/voidconductor

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -115,6 +115,7 @@ object KafkaProducer {
               )
 
               cancelable := Cancelable(() => future.cancel(false))
+              connection.push(cancelable)
             } catch {
               case NonFatal(ex) =>
                 // Needs synchronization, otherwise we are violating the contract

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -115,6 +115,7 @@ object KafkaProducer {
               )
 
               cancelable := Cancelable(() => future.cancel(false))
+              connection.push(cancelable)
             } catch {
               case NonFatal(ex) =>
                 // Needs synchronization, otherwise we are violating the contract

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -137,4 +137,22 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
       assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)
     }
   }
+
+  test("publish to closed producer when subscribed to topics list") {
+    withRunningKafka {
+      val producer = KafkaProducer[String, String](producerCfg, io)
+      val sendTask = producer.send(topicName, "test-message")
+
+      val result = for {
+        //Force creation of producer
+        s1 <- producer.send(topicName, "test-message-1")
+        res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+        (_, s2) = res
+        s3 <- sendTask
+      } yield (s1, s2, s3)
+
+      val (first, second, third) = Await.result(result.runToFuture, 60.seconds)
+      assert(first.isDefined && second.isRight && third.isEmpty)
+    }
+  }
 }

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -115,6 +115,7 @@ object KafkaProducer {
               )
 
               cancelable := Cancelable(() => future.cancel(false))
+              connection.push(cancelable)
             } catch {
               case NonFatal(ex) =>
                 // Needs synchronization, otherwise we are violating the contract

--- a/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -129,4 +129,20 @@ class MonixKafkaTest extends FunSuite {
     val properOffsets = Map(new TopicPartition(topicName, 0) -> 10000)
     assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)
   }
+
+  test("publish to closed producer when subscribed to topics list") {
+    val producer = KafkaProducer[String, String](producerCfg, io)
+    val sendTask = producer.send(topicName, "test-message")
+
+    val result = for {
+      //Force creation of producer
+      s1 <- producer.send(topicName, "test-message-1")
+      res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+      (_, s2) = res
+      s3 <- sendTask
+    } yield (s1, s2, s3)
+
+    val (first, second, third) = Await.result(result.runToFuture, 60.seconds)
+    assert(first.isDefined && second.isRight && third.isEmpty)
+  }
 }

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -65,11 +65,7 @@ object KafkaProducer {
     V: Serializer[V])
       extends KafkaProducer[K, V] with StrictLogging {
 
-    // Alias needed for being precise when blocking
-    self =>
-
-    // MUST BE synchronized by `self`
-    private[this] var isCanceled = false
+    private val isCanceled = Atomic(false)
 
     // Gets initialized on the first `send`
     private lazy val producerRef = {
@@ -91,47 +87,51 @@ object KafkaProducer {
         val asyncCb = Callback.forked(cb)(s)
         val connection = StackedCancelable()
         // Forcing asynchronous boundary
-        sc.executeAsync(() =>
-          self.synchronized {
-            if (isCanceled) {
-              asyncCb.onSuccess(None)
-            } else {
-              val isActive = Atomic(true)
-              val cancelable = SingleAssignCancelable()
-              try {
-                // Force evaluation
-                val producer = producerRef
+        sc.executeAsync(() => {
+          if (isCanceled.get()) {
+            asyncCb.onSuccess(None)
+          } else {
+            val isActive = Atomic(true)
+            val cancelable = SingleAssignCancelable()
+            try {
+              // Force evaluation
+              val producer = producerRef
 
-                // Using asynchronous API
-                val future = producer.send(
-                  record,
-                  new KafkaCallback {
-                    def onCompletion(meta: RecordMetadata, exception: Exception): Unit =
-                      if (isActive.getAndSet(false)) {
-                        connection.pop()
-                        if (exception != null)
-                          asyncCb.onError(exception)
-                        else
-                          asyncCb.onSuccess(Option(meta))
-                      } else if (exception != null) {
-                        s.reportFailure(exception)
-                      }
-                  }
-                )
+              // Using asynchronous API
+              val future = producer.send(
+                record,
+                new KafkaCallback {
+                  def onCompletion(meta: RecordMetadata, exception: Exception): Unit =
+                    if (isActive.getAndSet(false)) {
+                      connection.pop()
+                      if (exception != null)
+                        asyncCb.onError(exception)
+                      else
+                        asyncCb.onSuccess(Option(meta))
+                    } else if (exception != null) {
+                      s.reportFailure(exception)
+                    }
+                }
+              )
 
-                cancelable := Cancelable(() => future.cancel(false))
-              } catch {
-                case NonFatal(ex) =>
-                  // Needs synchronization, otherwise we are violating the contract
-                  if (isActive.compareAndSet(expect = true, update = false)) {
-                    connection.pop()
-                    asyncCb.onError(ex)
-                  } else {
-                    s.reportFailure(ex)
+              cancelable := Cancelable(() => future.cancel(false))
+            } catch {
+              case NonFatal(ex) =>
+                // Needs synchronization, otherwise we are violating the contract
+                if (isActive.compareAndSet(expect = true, update = false)) {
+                  connection.pop()
+                  ex match {
+                    case _: IllegalStateException =>
+                      asyncCb.onSuccess(None)
+                    case _ =>
+                      asyncCb.onError(ex)
                   }
-              }
+                } else {
+                  s.reportFailure(ex)
+                }
             }
-          })
+          }
+        })
         connection
       }
 
@@ -140,11 +140,10 @@ object KafkaProducer {
         val asyncCb = Callback.forked(cb)(s)
         // Forcing asynchronous boundary
         sc.executeAsync { () =>
-          self.synchronized {
-            if (isCanceled) {
+          {
+            if (!isCanceled.compareAndSet(expect = false, update = true)) {
               asyncCb.onSuccess(())
             } else {
-              isCanceled = true
               try {
                 producerRef.close()
                 asyncCb.onSuccess(())

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -121,7 +121,7 @@ object KafkaProducer {
                 if (isActive.compareAndSet(expect = true, update = false)) {
                   connection.pop()
                   ex match {
-                    case _: IllegalStateException =>
+                    case _: IllegalStateException if isCanceled.get() =>
                       asyncCb.onSuccess(None)
                     case _ =>
                       asyncCb.onError(ex)

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -115,6 +115,7 @@ object KafkaProducer {
               )
 
               cancelable := Cancelable(() => future.cancel(false))
+              connection.push(cancelable)
             } catch {
               case NonFatal(ex) =>
                 // Needs synchronization, otherwise we are violating the contract

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -139,4 +139,22 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
       assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)
     }
   }
+
+  test("publish to closed producer when subscribed to topics list") {
+    withRunningKafka {
+      val producer = KafkaProducer[String, String](producerCfg, io)
+      val sendTask = producer.send(topicName, "test-message")
+
+      val result = for {
+        //Force creation of producer
+        s1 <- producer.send(topicName, "test-message-1")
+        res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+        (_, s2) = res
+        s3 <- sendTask
+      } yield (s1, s2, s3)
+
+      val (first, second, third) = Await.result(result.runToFuture, 60.seconds)
+      assert(first.isDefined && second.isRight && third.isEmpty)
+    }
+  }
 }


### PR DESCRIPTION
- Replaced synchronization within `KafkaProducer` with simple checks

- Changed parallel sending in `KafkaProducerSink` to reduce allocations and improve performance