### PR TITLE
Allow Kafka Serializers

### DIFF
--- a/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -46,6 +46,12 @@ final case class Deserializer[A](
 
 object Deserializer {
 
+  implicit def fromKafkaDeserializer[A](implicit des: KafkaDeserializer[A]): Deserializer[A] =
+    Deserializer[A](
+      className = des.getClass.getName,
+      classType = des.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Deserializer`.
     */

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
@@ -46,6 +46,12 @@ final case class Serializer[A](
 
 object Serializer {
 
+  implicit def fromKafkaSerializer[A](implicit ser: KafkaSerializer[A]): Serializer[A] =
+    Serializer[A](
+      className = ser.getClass.getName,
+      classType = ser.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Serializer`.
     */

--- a/kafka-0.10.x/src/test/scala/monix/kafka/SerializationTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/SerializationTest.scala
@@ -1,0 +1,75 @@
+package monix.kafka
+
+import java.util
+
+import monix.eval.Task
+import monix.kafka.config.AutoOffsetReset
+import monix.reactive.Observable
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.FunSuite
+import org.apache.kafka.common.serialization.{Serializer => KafkaSerializer}
+import org.apache.kafka.common.serialization.{Deserializer => KafkaDeserializer}
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import monix.execution.Scheduler.Implicits.global
+
+class SerializationTest extends FunSuite with KafkaTestKit {
+  val topicName = "monix-kafka-serialization-tests"
+
+  val producerCfg = KafkaProducerConfig.default.copy(
+    bootstrapServers = List("127.0.0.1:6001"),
+    clientId = "monix-kafka-1-0-serialization-test"
+  )
+
+  val consumerCfg = KafkaConsumerConfig.default.copy(
+    bootstrapServers = List("127.0.0.1:6001"),
+    groupId = "kafka-tests",
+    clientId = "monix-kafka-1-0-serialization-test",
+    autoOffsetReset = AutoOffsetReset.Earliest
+  )
+
+  test("serialization/deserialization using kafka.common.serialization") {
+    withRunningKafka {
+      val count = 10000
+
+      implicit val serializer: KafkaSerializer[A] = new ASerializer
+      implicit val deserializer: KafkaDeserializer[A] = new ADeserializer
+
+      val producer = KafkaProducerSink[String, A](producerCfg, io)
+      val consumer = KafkaConsumerObservable[String, A](consumerCfg, List(topicName)).executeOn(io).take(count)
+
+      val pushT = Observable
+        .range(0, count)
+        .map(msg => new ProducerRecord(topicName, "obs", A(msg.toString)))
+        .bufferIntrospective(1024)
+        .consumeWith(producer)
+
+      val listT = consumer
+        .map(_.value())
+        .toListL
+
+      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      assert(result.map(_.value.toInt).sum === (0 until count).sum)
+    }
+  }
+
+}
+
+case class A(value: String)
+
+class ASerializer extends KafkaSerializer[A] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def serialize(topic: String, data: A): Array[Byte] =
+    if (data == null) null else data.value.getBytes
+
+  override def close(): Unit = ()
+}
+
+class ADeserializer extends KafkaDeserializer[A] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def deserialize(topic: String, data: Array[Byte]): A = if (data == null) null else A(new String(data))
+
+  override def close(): Unit = ()
+}

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -46,6 +46,12 @@ final case class Deserializer[A](
 
 object Deserializer {
 
+  implicit def fromKafkaDeserializer[A](implicit des: KafkaDeserializer[A]): Deserializer[A] =
+    Deserializer[A](
+      className = des.getClass.getName,
+      classType = des.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Deserializer`.
     */

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Serializer.scala
@@ -46,6 +46,12 @@ final case class Serializer[A](
 
 object Serializer {
 
+  implicit def fromKafkaSerializer[A](implicit ser: KafkaSerializer[A]): Serializer[A] =
+    Serializer[A](
+      className = ser.getClass.getName,
+      classType = ser.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Serializer`.
     */

--- a/kafka-0.11.x/src/test/scala/monix/kafka/SerializationTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/SerializationTest.scala
@@ -1,0 +1,75 @@
+package monix.kafka
+
+import java.util
+
+import monix.eval.Task
+import monix.kafka.config.AutoOffsetReset
+import monix.reactive.Observable
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.FunSuite
+import org.apache.kafka.common.serialization.{Serializer => KafkaSerializer}
+import org.apache.kafka.common.serialization.{Deserializer => KafkaDeserializer}
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import monix.execution.Scheduler.Implicits.global
+
+class SerializationTest extends FunSuite with KafkaTestKit {
+  val topicName = "monix-kafka-serialization-tests"
+
+  val producerCfg = KafkaProducerConfig.default.copy(
+    bootstrapServers = List("127.0.0.1:6001"),
+    clientId = "monix-kafka-1-0-serialization-test"
+  )
+
+  val consumerCfg = KafkaConsumerConfig.default.copy(
+    bootstrapServers = List("127.0.0.1:6001"),
+    groupId = "kafka-tests",
+    clientId = "monix-kafka-1-0-serialization-test",
+    autoOffsetReset = AutoOffsetReset.Earliest
+  )
+
+  test("serialization/deserialization using kafka.common.serialization") {
+    withRunningKafka {
+      val count = 10000
+
+      implicit val serializer: KafkaSerializer[A] = new ASerializer
+      implicit val deserializer: KafkaDeserializer[A] = new ADeserializer
+
+      val producer = KafkaProducerSink[String, A](producerCfg, io)
+      val consumer = KafkaConsumerObservable[String, A](consumerCfg, List(topicName)).executeOn(io).take(count)
+
+      val pushT = Observable
+        .range(0, count)
+        .map(msg => new ProducerRecord(topicName, "obs", A(msg.toString)))
+        .bufferIntrospective(1024)
+        .consumeWith(producer)
+
+      val listT = consumer
+        .map(_.value())
+        .toListL
+
+      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      assert(result.map(_.value.toInt).sum === (0 until count).sum)
+    }
+  }
+
+}
+
+case class A(value: String)
+
+class ASerializer extends KafkaSerializer[A] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def serialize(topic: String, data: A): Array[Byte] =
+    if (data == null) null else data.value.getBytes
+
+  override def close(): Unit = ()
+}
+
+class ADeserializer extends KafkaDeserializer[A] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def deserialize(topic: String, data: Array[Byte]): A = if (data == null) null else A(new String(data))
+
+  override def close(): Unit = ()
+}

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -44,6 +44,12 @@ final case class Deserializer[A](
 
 object Deserializer {
 
+  implicit def fromKafkaDeserializer[A](implicit des: KafkaDeserializer[A]): Deserializer[A] =
+    Deserializer[A](
+      className = des.getClass.getName,
+      classType = des.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Deserializer`.
     */

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
@@ -44,6 +44,12 @@ final case class Serializer[A](
 
 object Serializer {
 
+  implicit def fromKafkaSerializer[A](implicit ser: KafkaSerializer[A]): Serializer[A] =
+    Serializer[A](
+      className = ser.getClass.getName,
+      classType = ser.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Serializer`.
     */

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -46,6 +46,12 @@ final case class Deserializer[A](
 
 object Deserializer {
 
+  implicit def fromKafkaDeserializer[A](implicit des: KafkaDeserializer[A]): Deserializer[A] =
+    Deserializer[A](
+      className = des.getClass.getName,
+      classType = des.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Deserializer`.
     */

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Serializer.scala
@@ -46,6 +46,12 @@ final case class Serializer[A](
 
 object Serializer {
 
+  implicit def fromKafkaSerializer[A](implicit ser: KafkaSerializer[A]): Serializer[A] =
+    Serializer[A](
+      className = ser.getClass.getName,
+      classType = ser.getClass
+    )
+
   /** Alias for the function that provides an instance of
     * the Kafka `Serializer`.
     */

--- a/kafka-1.0.x/src/test/scala/monix/kafka/SerializationTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/SerializationTest.scala
@@ -1,0 +1,75 @@
+package monix.kafka
+
+import java.util
+
+import monix.eval.Task
+import monix.kafka.config.AutoOffsetReset
+import monix.reactive.Observable
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.FunSuite
+import org.apache.kafka.common.serialization.{Serializer => KafkaSerializer}
+import org.apache.kafka.common.serialization.{Deserializer => KafkaDeserializer}
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import monix.execution.Scheduler.Implicits.global
+
+class SerializationTest extends FunSuite with KafkaTestKit {
+  val topicName = "monix-kafka-serialization-tests"
+
+  val producerCfg = KafkaProducerConfig.default.copy(
+    bootstrapServers = List("127.0.0.1:6001"),
+    clientId = "monix-kafka-1-0-serialization-test"
+  )
+
+  val consumerCfg = KafkaConsumerConfig.default.copy(
+    bootstrapServers = List("127.0.0.1:6001"),
+    groupId = "kafka-tests",
+    clientId = "monix-kafka-1-0-serialization-test",
+    autoOffsetReset = AutoOffsetReset.Earliest
+  )
+
+  test("serialization/deserialization using kafka.common.serialization") {
+    withRunningKafka {
+      val count = 10000
+
+      implicit val serializer: KafkaSerializer[A] = new ASerializer
+      implicit val deserializer: KafkaDeserializer[A] = new ADeserializer
+
+      val producer = KafkaProducerSink[String, A](producerCfg, io)
+      val consumer = KafkaConsumerObservable[String, A](consumerCfg, List(topicName)).executeOn(io).take(count)
+
+      val pushT = Observable
+        .range(0, count)
+        .map(msg => new ProducerRecord(topicName, "obs", A(msg.toString)))
+        .bufferIntrospective(1024)
+        .consumeWith(producer)
+
+      val listT = consumer
+        .map(_.value())
+        .toListL
+
+      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      assert(result.map(_.value.toInt).sum === (0 until count).sum)
+    }
+  }
+
+}
+
+case class A(value: String)
+
+class ASerializer extends KafkaSerializer[A] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def serialize(topic: String, data: A): Array[Byte] =
+    if (data == null) null else data.value.getBytes
+
+  override def close(): Unit = ()
+}
+
+class ADeserializer extends KafkaDeserializer[A] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def deserialize(topic: String, data: Array[Byte]): A = if (data == null) null else A(new String(data))
+
+  override def close(): Unit = ()
+}


### PR DESCRIPTION
fixes #90

I don't know why the library defines its own `Serializer` / `Deserializer`, I've only found this PR: https://github.com/monix/monix-kafka/pull/5

This PR will allow to use any Kafka (de)serializers too via implicit conversion. Not ideal but the cost should be pretty much 0 and I'm hesitant to break everything