### PR TITLE
Remove redundant executeAsync in parallel operators in tests

### DIFF
--- a/kafka-0.10.x/src/test/scala/monix/kafka/MergeByCommitCallbackTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MergeByCommitCallbackTest.scala
@@ -69,7 +69,7 @@ class MergeByCommitCallbackTest extends FunSuite with KafkaTestKit with ScalaChe
         }
         .completedL
 
-      Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
     }
   }
 

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -104,7 +104,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.toInt).sum === (0 until count).sum)
     }
   }
@@ -134,7 +134,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
         .headL
 
       val ((result, offsets), _) =
-        Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+        Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
 
       val properOffsets = Map(new TopicPartition(topicName, 0) -> 10000)
       assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
@@ -100,7 +100,7 @@ class MonixKafkaTopicRegexTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.toInt).sum === (0 until count).sum)
     }
   }

--- a/kafka-0.10.x/src/test/scala/monix/kafka/SerializationTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/SerializationTest.scala
@@ -48,7 +48,7 @@ class SerializationTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.value.toInt).sum === (0 until count).sum)
     }
   }

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MergeByCommitCallbackTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MergeByCommitCallbackTest.scala
@@ -69,7 +69,7 @@ class MergeByCommitCallbackTest extends FunSuite with KafkaTestKit with ScalaChe
         }
         .completedL
 
-      Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
     }
   }
 

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -102,7 +102,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.toInt).sum === (0 until count).sum)
     }
   }
@@ -131,7 +131,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
         .headL
 
       val ((result, offsets), _) =
-        Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+        Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
 
       val properOffsets = Map(new TopicPartition(topicName, 0) -> 10000)
       assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
@@ -101,7 +101,7 @@ class MonixKafkaTopicRegexTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.toInt).sum === (0 until count).sum)
     }
   }

--- a/kafka-0.11.x/src/test/scala/monix/kafka/SerializationTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/SerializationTest.scala
@@ -48,7 +48,7 @@ class SerializationTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.value.toInt).sum === (0 until count).sum)
     }
   }

--- a/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -97,7 +97,7 @@ class MonixKafkaTest extends FunSuite {
       .map(_.value())
       .toListL
 
-    val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+    val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
     assert(result.map(_.toInt).sum === (0 until count).sum)
   }
 
@@ -124,7 +124,7 @@ class MonixKafkaTest extends FunSuite {
       .headL
 
     val ((result, offsets), _) =
-      Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
 
     val properOffsets = Map(new TopicPartition(topicName, 0) -> 10000)
     assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)
@@ -188,6 +188,6 @@ class MonixKafkaTest extends FunSuite {
         assert(offsetBatches.length == 2)
       }
       .headL
-    Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+    Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
   }
 }

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MergeByCommitCallbackTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MergeByCommitCallbackTest.scala
@@ -69,7 +69,7 @@ class MergeByCommitCallbackTest extends FunSuite with KafkaTestKit with ScalaChe
         }
         .completedL
 
-      Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
     }
   }
 

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -103,7 +103,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.toInt).sum === (0 until count).sum)
     }
   }
@@ -133,7 +133,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
         .headL
 
       val ((result, offsets), _) =
-        Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+        Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
 
       val properOffsets = Map(new TopicPartition(topicName, 0) -> 10000)
       assert(result.map(_.toInt).sum === (0 until count).sum && offsets === properOffsets)

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicRegexTest.scala
@@ -101,7 +101,7 @@ class MonixKafkaTopicRegexTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.toInt).sum === (0 until count).sum)
     }
   }

--- a/kafka-1.0.x/src/test/scala/monix/kafka/SerializationTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/SerializationTest.scala
@@ -48,7 +48,7 @@ class SerializationTest extends FunSuite with KafkaTestKit {
         .map(_.value())
         .toListL
 
-      val (result, _) = Await.result(Task.parZip2(listT.executeAsync, pushT.executeAsync).runToFuture, 60.seconds)
+      val (result, _) = Await.result(Task.parZip2(listT, pushT).runToFuture, 60.seconds)
       assert(result.map(_.value.toInt).sum === (0 until count).sum)
     }
   }


### PR DESCRIPTION
Closes #129 