### PR TITLE
use Kafka Producer Consumer interfaces

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,6 @@ https://github.com/voidconductor
 
 Adriel Velazquez
 https://github.com/AdrielVelazquez
+
+Arun Gopalpuri
+https://github.com/arun0009

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -23,7 +23,7 @@ import monix.kafka.config.ObservableCommitOrder
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
-import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.blocking
@@ -38,13 +38,13 @@ import scala.util.matching.Regex
   */
 trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   protected def config: KafkaConsumerConfig
-  protected def consumer: Task[KafkaConsumer[K, V]]
+  protected def consumer: Task[Consumer[K, V]]
 
   /**
     * Creates a task that polls the source, then feeds the downstream
     * subscriber, returning the resulting acknowledgement
     * */
-  protected def ackTask(consumer: KafkaConsumer[K, V], out: Subscriber[Out]): Task[Ack]
+  protected def ackTask(consumer: Consumer[K, V], out: Subscriber[Out]): Task[Ack]
 
   override final def unsafeSubscribeFn(out: Subscriber[Out]): Cancelable = {
     import out.scheduler
@@ -79,7 +79,7 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
    *
    * Creates an asynchronous boundary on every poll.
    */
-  private def runLoop(consumer: KafkaConsumer[K, V], out: Subscriber[Out]): Task[Unit] = {
+  private def runLoop(consumer: Consumer[K, V], out: Subscriber[Out]): Task[Unit] = {
     ackTask(consumer, out).flatMap {
       case Stop => Task.unit
       case Continue => runLoop(consumer, out)
@@ -89,7 +89,7 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   /* Returns a `Task` that triggers the closing of the
    * Kafka Consumer connection.
    */
-  private def cancelTask(consumer: KafkaConsumer[K, V]): Task[Unit] = {
+  private def cancelTask(consumer: Consumer[K, V]): Task[Unit] = {
     // Forced asynchronous boundary
     val cancelTask = Task.evalAsync {
       consumer.synchronized(blocking(consumer.close()))
@@ -117,7 +117,7 @@ object KafkaConsumerObservable {
     */
   def apply[K, V](
     cfg: KafkaConsumerConfig,
-    consumer: Task[KafkaConsumer[K, V]]): KafkaConsumerObservable[K, V, ConsumerRecord[K, V]] =
+    consumer: Task[Consumer[K, V]]): KafkaConsumerObservable[K, V, ConsumerRecord[K, V]] =
     new KafkaConsumerObservableAutoCommit[K, V](cfg, consumer)
 
   /** Builds a [[KafkaConsumerObservable]] instance.
@@ -178,7 +178,7 @@ object KafkaConsumerObservable {
     * */
   def manualCommit[K, V](
     cfg: KafkaConsumerConfig,
-    consumer: Task[KafkaConsumer[K, V]]): KafkaConsumerObservable[K, V, CommittableMessage[K, V]] = {
+    consumer: Task[Consumer[K, V]]): KafkaConsumerObservable[K, V, CommittableMessage[K, V]] = {
 
     val manualCommitConfig = cfg.copy(observableCommitOrder = ObservableCommitOrder.NoAck, enableAutoCommit = false)
     new KafkaConsumerObservableManualCommit[K, V](manualCommitConfig, consumer)
@@ -247,7 +247,7 @@ object KafkaConsumerObservable {
   /** Returns a `Task` for creating a consumer instance given list of topics. */
   def createConsumer[K, V](config: KafkaConsumerConfig, topics: List[String])(
     implicit K: Deserializer[K],
-    V: Deserializer[V]): Task[KafkaConsumer[K, V]] = {
+    V: Deserializer[V]): Task[Consumer[K, V]] = {
 
     import collection.JavaConverters._
     Task.evalAsync {
@@ -263,7 +263,7 @@ object KafkaConsumerObservable {
   /** Returns a `Task` for creating a consumer instance given topics regex. */
   def createConsumer[K, V](config: KafkaConsumerConfig, topicsRegex: Regex)(
     implicit K: Deserializer[K],
-    V: Deserializer[V]): Task[KafkaConsumer[K, V]] = {
+    V: Deserializer[V]): Task[Consumer[K, V]] = {
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -25,8 +25,8 @@ import org.apache.kafka.clients.producer.{
   ProducerRecord,
   RecordMetadata,
   Callback => KafkaCallback,
-  KafkaProducer => ApacheKafkaProducer
-}
+  Producer => ApacheProducer,
+  KafkaProducer => ApacheKafkaProducer}
 
 import scala.util.control.NonFatal
 
@@ -45,7 +45,7 @@ import scala.util.control.NonFatal
   * All successfully delivered messages will complete with `Some[RecordMetadata]`.
   */
 trait KafkaProducer[K, V] extends Serializable {
-  def underlying: Task[ApacheKafkaProducer[K, V]]
+  def underlying: Task[ApacheProducer[K, V]]
   def send(topic: String, value: V): Task[Option[RecordMetadata]]
   def send(topic: String, key: K, value: V): Task[Option[RecordMetadata]]
   def send(record: ProducerRecord[K, V]): Task[Option[RecordMetadata]]
@@ -78,7 +78,7 @@ object KafkaProducer {
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
 
-    def underlying: Task[ApacheKafkaProducer[K, V]] =
+    def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)
 
     def send(topic: String, value: V): Task[Option[RecordMetadata]] =

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -57,19 +57,8 @@ object KafkaProducer {
   /** Builds a [[KafkaProducer]] instance. */
   def apply[K, V](config: KafkaProducerConfig, sc: Scheduler)(
     implicit K: Serializer[K],
-    V: Serializer[V]): KafkaProducer[K, V] =
-    new Implementation[K, V](config, sc)
-
-  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler)(
-    implicit K: Serializer[K],
-    V: Serializer[V])
-      extends KafkaProducer[K, V] with StrictLogging {
-
-    private val isCanceled = Atomic(false)
-
-    // Gets initialized on the first `send`
-    private lazy val producerRef = {
-      logger.info(s"Kafka producer connecting to servers: ${config.bootstrapServers.mkString(",")}")
+    V: Serializer[V]): KafkaProducer[K, V] = {
+    lazy val producerRef: ApacheProducer[K, V] = {
       val keySerializer = K.create()
       val valueSerializer = V.create()
       val configJavaMap = config.toJavaMap
@@ -77,6 +66,22 @@ object KafkaProducer {
       valueSerializer.configure(configJavaMap, false)
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
+    new Implementation[K, V](config, sc, producerRef)
+  }
+
+  /** Builds a [[KafkaProducer]] instance with provided Apache Producer. */
+  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+    implicit K: Serializer[K],
+    V: Serializer[V]): KafkaProducer[K, V] = {
+    new Implementation[K, V](config, sc, producerRef)
+  }
+
+  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+    implicit K: Serializer[K],
+    V: Serializer[V])
+      extends KafkaProducer[K, V] with StrictLogging {
+
+    private val isCanceled = Atomic(false)
 
     def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -62,7 +62,7 @@ final class KafkaProducerSink[K, V] private (
               if (parallelism == 1)
                 Task.traverse(list)(p.value().send(_))
               else {
-                Task.wanderN(parallelism)(list)(r => p.value().send(r))
+                Task.parTraverseN(parallelism)(list)(r => p.value().send(r))
               }
 
             val recovered = sendTask.redeemWith(

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -17,7 +17,6 @@
 
 package monix.kafka
 
-import cats.syntax.apply._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.kafka.config.AutoOffsetReset

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -23,7 +23,7 @@ import monix.kafka.config.ObservableCommitOrder
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
-import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.blocking
@@ -38,13 +38,13 @@ import scala.util.matching.Regex
   */
 trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   protected def config: KafkaConsumerConfig
-  protected def consumer: Task[KafkaConsumer[K, V]]
+  protected def consumer: Task[Consumer[K, V]]
 
   /**
     * Creates a task that polls the source, then feeds the downstream
     * subscriber, returning the resulting acknowledgement
     * */
-  protected def ackTask(consumer: KafkaConsumer[K, V], out: Subscriber[Out]): Task[Ack]
+  protected def ackTask(consumer: Consumer[K, V], out: Subscriber[Out]): Task[Ack]
 
   override final def unsafeSubscribeFn(out: Subscriber[Out]): Cancelable = {
     import out.scheduler
@@ -79,7 +79,7 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
    *
    * Creates an asynchronous boundary on every poll.
    */
-  private def runLoop(consumer: KafkaConsumer[K, V], out: Subscriber[Out]): Task[Unit] = {
+  private def runLoop(consumer: Consumer[K, V], out: Subscriber[Out]): Task[Unit] = {
     ackTask(consumer, out).flatMap {
       case Stop => Task.unit
       case Continue => runLoop(consumer, out)
@@ -89,7 +89,7 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   /* Returns a `Task` that triggers the closing of the
    * Kafka Consumer connection.
    */
-  private def cancelTask(consumer: KafkaConsumer[K, V]): Task[Unit] = {
+  private def cancelTask(consumer: Consumer[K, V]): Task[Unit] = {
     // Forced asynchronous boundary
     val cancelTask = Task.evalAsync {
       consumer.synchronized(blocking(consumer.close()))
@@ -117,7 +117,7 @@ object KafkaConsumerObservable {
     */
   def apply[K, V](
     cfg: KafkaConsumerConfig,
-    consumer: Task[KafkaConsumer[K, V]]): KafkaConsumerObservable[K, V, ConsumerRecord[K, V]] =
+    consumer: Task[Consumer[K, V]]): KafkaConsumerObservable[K, V, ConsumerRecord[K, V]] =
     new KafkaConsumerObservableAutoCommit[K, V](cfg, consumer)
 
   /** Builds a [[KafkaConsumerObservable]] instance.
@@ -178,7 +178,7 @@ object KafkaConsumerObservable {
     * */
   def manualCommit[K, V](
     cfg: KafkaConsumerConfig,
-    consumer: Task[KafkaConsumer[K, V]]): KafkaConsumerObservable[K, V, CommittableMessage[K, V]] = {
+    consumer: Task[Consumer[K, V]]): KafkaConsumerObservable[K, V, CommittableMessage[K, V]] = {
 
     val manualCommitConfig = cfg.copy(observableCommitOrder = ObservableCommitOrder.NoAck, enableAutoCommit = false)
     new KafkaConsumerObservableManualCommit[K, V](manualCommitConfig, consumer)
@@ -247,7 +247,7 @@ object KafkaConsumerObservable {
   /** Returns a `Task` for creating a consumer instance given list of topics. */
   def createConsumer[K, V](config: KafkaConsumerConfig, topics: List[String])(
     implicit K: Deserializer[K],
-    V: Deserializer[V]): Task[KafkaConsumer[K, V]] = {
+    V: Deserializer[V]): Task[Consumer[K, V]] = {
 
     import collection.JavaConverters._
     Task.evalAsync {
@@ -263,7 +263,7 @@ object KafkaConsumerObservable {
   /** Returns a `Task` for creating a consumer instance given topics regex. */
   def createConsumer[K, V](config: KafkaConsumerConfig, topicsRegex: Regex)(
     implicit K: Deserializer[K],
-    V: Deserializer[V]): Task[KafkaConsumer[K, V]] = {
+    V: Deserializer[V]): Task[Consumer[K, V]] = {
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -25,8 +25,8 @@ import org.apache.kafka.clients.producer.{
   ProducerRecord,
   RecordMetadata,
   Callback => KafkaCallback,
-  KafkaProducer => ApacheKafkaProducer
-}
+  Producer => ApacheProducer,
+  KafkaProducer => ApacheKafkaProducer}
 
 import scala.util.control.NonFatal
 
@@ -45,7 +45,7 @@ import scala.util.control.NonFatal
   * All successfully delivered messages will complete with `Some[RecordMetadata]`.
   */
 trait KafkaProducer[K, V] extends Serializable {
-  def underlying: Task[ApacheKafkaProducer[K, V]]
+  def underlying: Task[ApacheProducer[K, V]]
   def send(topic: String, value: V): Task[Option[RecordMetadata]]
   def send(topic: String, key: K, value: V): Task[Option[RecordMetadata]]
   def send(record: ProducerRecord[K, V]): Task[Option[RecordMetadata]]
@@ -78,7 +78,7 @@ object KafkaProducer {
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
 
-    def underlying: Task[ApacheKafkaProducer[K, V]] =
+    def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)
 
     def send(topic: String, value: V): Task[Option[RecordMetadata]] =

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -57,19 +57,8 @@ object KafkaProducer {
   /** Builds a [[KafkaProducer]] instance. */
   def apply[K, V](config: KafkaProducerConfig, sc: Scheduler)(
     implicit K: Serializer[K],
-    V: Serializer[V]): KafkaProducer[K, V] =
-    new Implementation[K, V](config, sc)
-
-  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler)(
-    implicit K: Serializer[K],
-    V: Serializer[V])
-      extends KafkaProducer[K, V] with StrictLogging {
-
-    private val isCanceled = Atomic(false)
-
-    // Gets initialized on the first `send`
-    private lazy val producerRef = {
-      logger.info(s"Kafka producer connecting to servers: ${config.bootstrapServers.mkString(",")}")
+    V: Serializer[V]): KafkaProducer[K, V] = {
+    lazy val producerRef: ApacheProducer[K, V] = {
       val keySerializer = K.create()
       val valueSerializer = V.create()
       val configJavaMap = config.toJavaMap
@@ -77,6 +66,22 @@ object KafkaProducer {
       valueSerializer.configure(configJavaMap, false)
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
+    new Implementation[K, V](config, sc, producerRef)
+  }
+
+  /** Builds a [[KafkaProducer]] instance with provided Apache Producer. */
+  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+    implicit K: Serializer[K],
+    V: Serializer[V]): KafkaProducer[K, V] = {
+    new Implementation[K, V](config, sc, producerRef)
+  }
+
+  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+    implicit K: Serializer[K],
+    V: Serializer[V])
+      extends KafkaProducer[K, V] with StrictLogging {
+
+    private val isCanceled = Atomic(false)
 
     def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -17,7 +17,7 @@
 package monix.kafka
 
 import com.typesafe.scalalogging.StrictLogging
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.{SingleAssignCancelable, StackedCancelable}
 import monix.execution.{Callback, Cancelable, Scheduler}
@@ -58,7 +58,7 @@ object KafkaProducer {
   def apply[K, V](config: KafkaProducerConfig, sc: Scheduler)(
     implicit K: Serializer[K],
     V: Serializer[V]): KafkaProducer[K, V] = {
-    lazy val producerRef: ApacheProducer[K, V] = {
+    val producerRef: Coeval[ApacheProducer[K, V]] = Coeval.evalOnce {
       val keySerializer = K.create()
       val valueSerializer = V.create()
       val configJavaMap = config.toJavaMap
@@ -70,13 +70,13 @@ object KafkaProducer {
   }
 
   /** Builds a [[KafkaProducer]] instance with provided Apache Producer. */
-  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: Coeval[ApacheProducer[K, V]])(
     implicit K: Serializer[K],
     V: Serializer[V]): KafkaProducer[K, V] = {
     new Implementation[K, V](config, sc, producerRef)
   }
 
-  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: Coeval[ApacheProducer[K, V]])(
     implicit K: Serializer[K],
     V: Serializer[V])
       extends KafkaProducer[K, V] with StrictLogging {
@@ -84,7 +84,7 @@ object KafkaProducer {
     private val isCanceled = Atomic(false)
 
     def underlying: Task[ApacheProducer[K, V]] =
-      Task.eval(producerRef)
+      producerRef.to[Task]
 
     def send(topic: String, value: V): Task[Option[RecordMetadata]] =
       send(new ProducerRecord[K, V](topic, value))
@@ -104,11 +104,8 @@ object KafkaProducer {
             val isActive = Atomic(true)
             val cancelable = SingleAssignCancelable()
             try {
-              // Force evaluation
-              val producer = producerRef
-
               // Using asynchronous API
-              val future = producer.send(
+              val future = producerRef.value().send(
                 record,
                 new KafkaCallback {
                   def onCompletion(meta: RecordMetadata, exception: Exception): Unit =
@@ -156,7 +153,7 @@ object KafkaProducer {
               asyncCb.onSuccess(())
             } else {
               try {
-                producerRef.close()
+                producerRef.value().close()
                 asyncCb.onSuccess(())
               } catch {
                 case NonFatal(ex) =>

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -62,7 +62,7 @@ final class KafkaProducerSink[K, V] private (
               if (parallelism == 1)
                 Task.traverse(list)(p.value().send(_))
               else {
-                Task.wanderN(parallelism)(list)(r => p.value().send(r))
+                Task.parTraverseN(parallelism)(list)(r => p.value().send(r))
               }
 
             val recovered = sendTask.redeemWith(

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -17,7 +17,6 @@
 
 package monix.kafka
 
-import cats.syntax.apply._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.kafka.config.AutoOffsetReset

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.{
   ProducerRecord,
   RecordMetadata,
   Callback => KafkaCallback,
+  Producer => ApacheProducer,
   KafkaProducer => ApacheKafkaProducer
 }
 
@@ -45,7 +46,7 @@ import scala.util.control.NonFatal
   * All successfully delivered messages will complete with `Some[RecordMetadata]`.
   */
 trait KafkaProducer[K, V] extends Serializable {
-  def underlying: Task[ApacheKafkaProducer[K, V]]
+  def underlying: Task[ApacheProducer[K, V]]
   def send(topic: String, value: V): Task[Option[RecordMetadata]]
   def send(topic: String, key: K, value: V): Task[Option[RecordMetadata]]
   def send(record: ProducerRecord[K, V]): Task[Option[RecordMetadata]]
@@ -78,7 +79,7 @@ object KafkaProducer {
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
 
-    def underlying: Task[ApacheKafkaProducer[K, V]] =
+    def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)
 
     def send(topic: String, value: V): Task[Option[RecordMetadata]] =

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -62,7 +62,7 @@ final class KafkaProducerSink[K, V] private (
               if (parallelism == 1)
                 Task.traverse(list)(p.value().send(_))
               else {
-                Task.wanderN(parallelism)(list)(r => p.value().send(r))
+                Task.parTraverseN(parallelism)(list)(r => p.value().send(r))
               }
 
             val recovered = sendTask.redeemWith(

--- a/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -17,7 +17,6 @@
 
 package monix.kafka
 
-import cats.syntax.apply._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.kafka.config.AutoOffsetReset

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -22,7 +22,7 @@ import monix.execution.{Ack, Callback, Cancelable}
 import monix.kafka.config.ObservableCommitOrder
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
-import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.blocking
@@ -37,13 +37,13 @@ import scala.util.matching.Regex
   */
 trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   protected def config: KafkaConsumerConfig
-  protected def consumer: Task[KafkaConsumer[K, V]]
+  protected def consumer: Task[Consumer[K, V]]
 
   /**
     * Creates a task that polls the source, then feeds the downstream
     * subscriber, returning the resulting acknowledgement
     * */
-  protected def ackTask(consumer: KafkaConsumer[K, V], out: Subscriber[Out]): Task[Ack]
+  protected def ackTask(consumer: Consumer[K, V], out: Subscriber[Out]): Task[Ack]
 
   override final def unsafeSubscribeFn(out: Subscriber[Out]): Cancelable = {
     import out.scheduler
@@ -78,7 +78,7 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
    *
    * Creates an asynchronous boundary on every poll.
    */
-  private def runLoop(consumer: KafkaConsumer[K, V], out: Subscriber[Out]): Task[Unit] = {
+  private def runLoop(consumer: Consumer[K, V], out: Subscriber[Out]): Task[Unit] = {
     ackTask(consumer, out).flatMap {
       case Stop => Task.unit
       case Continue => runLoop(consumer, out)
@@ -88,7 +88,7 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   /* Returns a `Task` that triggers the closing of the
    * Kafka Consumer connection.
    */
-  private def cancelTask(consumer: KafkaConsumer[K, V]): Task[Unit] = {
+  private def cancelTask(consumer: Consumer[K, V]): Task[Unit] = {
     // Forced asynchronous boundary
     val cancelTask = Task.evalAsync {
       consumer.synchronized(blocking(consumer.close()))
@@ -116,7 +116,7 @@ object KafkaConsumerObservable {
     */
   def apply[K, V](
     cfg: KafkaConsumerConfig,
-    consumer: Task[KafkaConsumer[K, V]]): KafkaConsumerObservable[K, V, ConsumerRecord[K, V]] =
+    consumer: Task[Consumer[K, V]]): KafkaConsumerObservable[K, V, ConsumerRecord[K, V]] =
     new KafkaConsumerObservableAutoCommit[K, V](cfg, consumer)
 
   /** Builds a [[KafkaConsumerObservable]] instance.
@@ -177,7 +177,7 @@ object KafkaConsumerObservable {
     * */
   def manualCommit[K, V](
     cfg: KafkaConsumerConfig,
-    consumer: Task[KafkaConsumer[K, V]]): KafkaConsumerObservable[K, V, CommittableMessage[K, V]] = {
+    consumer: Task[Consumer[K, V]]): KafkaConsumerObservable[K, V, CommittableMessage[K, V]] = {
 
     val manualCommitConfig = cfg.copy(observableCommitOrder = ObservableCommitOrder.NoAck, enableAutoCommit = false)
     new KafkaConsumerObservableManualCommit[K, V](manualCommitConfig, consumer)
@@ -246,7 +246,7 @@ object KafkaConsumerObservable {
   /** Returns a `Task` for creating a consumer instance given list of topics. */
   def createConsumer[K, V](config: KafkaConsumerConfig, topics: List[String])(
     implicit K: Deserializer[K],
-    V: Deserializer[V]): Task[KafkaConsumer[K, V]] = {
+    V: Deserializer[V]): Task[Consumer[K, V]] = {
 
     import collection.JavaConverters._
     Task.evalAsync {
@@ -262,7 +262,7 @@ object KafkaConsumerObservable {
   /** Returns a `Task` for creating a consumer instance given topics regex. */
   def createConsumer[K, V](config: KafkaConsumerConfig, topicsRegex: Regex)(
     implicit K: Deserializer[K],
-    V: Deserializer[V]): Task[KafkaConsumer[K, V]] = {
+    V: Deserializer[V]): Task[Consumer[K, V]] = {
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -25,8 +25,8 @@ import org.apache.kafka.clients.producer.{
   ProducerRecord,
   RecordMetadata,
   Callback => KafkaCallback,
-  KafkaProducer => ApacheKafkaProducer
-}
+  Producer => ApacheProducer,
+  KafkaProducer => ApacheKafkaProducer}
 
 import scala.util.control.NonFatal
 
@@ -45,7 +45,7 @@ import scala.util.control.NonFatal
   * All successfully delivered messages will complete with `Some[RecordMetadata]`.
   */
 trait KafkaProducer[K, V] extends Serializable {
-  def underlying: Task[ApacheKafkaProducer[K, V]]
+  def underlying: Task[ApacheProducer[K, V]]
   def send(topic: String, value: V): Task[Option[RecordMetadata]]
   def send(topic: String, key: K, value: V): Task[Option[RecordMetadata]]
   def send(record: ProducerRecord[K, V]): Task[Option[RecordMetadata]]
@@ -78,7 +78,7 @@ object KafkaProducer {
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
 
-    def underlying: Task[ApacheKafkaProducer[K, V]] =
+    def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)
 
     def send(topic: String, value: V): Task[Option[RecordMetadata]] =

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -57,19 +57,8 @@ object KafkaProducer {
   /** Builds a [[KafkaProducer]] instance. */
   def apply[K, V](config: KafkaProducerConfig, sc: Scheduler)(
     implicit K: Serializer[K],
-    V: Serializer[V]): KafkaProducer[K, V] =
-    new Implementation[K, V](config, sc)
-
-  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler)(
-    implicit K: Serializer[K],
-    V: Serializer[V])
-      extends KafkaProducer[K, V] with StrictLogging {
-
-    private val isCanceled = Atomic(false)
-
-    // Gets initialized on the first `send`
-    private lazy val producerRef = {
-      logger.info(s"Kafka producer connecting to servers: ${config.bootstrapServers.mkString(",")}")
+    V: Serializer[V]): KafkaProducer[K, V] = {
+    lazy val producerRef: ApacheProducer[K, V] = {
       val keySerializer = K.create()
       val valueSerializer = V.create()
       val configJavaMap = config.toJavaMap
@@ -77,6 +66,22 @@ object KafkaProducer {
       valueSerializer.configure(configJavaMap, false)
       new ApacheKafkaProducer[K, V](configJavaMap, keySerializer, valueSerializer)
     }
+    new Implementation[K, V](config, sc, producerRef)
+  }
+
+  /** Builds a [[KafkaProducer]] instance with provided Apache Producer. */
+  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+    implicit K: Serializer[K],
+    V: Serializer[V]): KafkaProducer[K, V] = {
+    new Implementation[K, V](config, sc, producerRef)
+  }
+
+  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+    implicit K: Serializer[K],
+    V: Serializer[V])
+      extends KafkaProducer[K, V] with StrictLogging {
+
+    private val isCanceled = Atomic(false)
 
     def underlying: Task[ApacheProducer[K, V]] =
       Task.eval(producerRef)

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -17,7 +17,7 @@
 package monix.kafka
 
 import com.typesafe.scalalogging.StrictLogging
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.{SingleAssignCancelable, StackedCancelable}
 import monix.execution.{Callback, Cancelable, Scheduler}
@@ -58,7 +58,7 @@ object KafkaProducer {
   def apply[K, V](config: KafkaProducerConfig, sc: Scheduler)(
     implicit K: Serializer[K],
     V: Serializer[V]): KafkaProducer[K, V] = {
-    lazy val producerRef: ApacheProducer[K, V] = {
+    val producerRef: Coeval[ApacheProducer[K, V]] = Coeval.evalOnce {
       val keySerializer = K.create()
       val valueSerializer = V.create()
       val configJavaMap = config.toJavaMap
@@ -70,13 +70,13 @@ object KafkaProducer {
   }
 
   /** Builds a [[KafkaProducer]] instance with provided Apache Producer. */
-  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+  def apply[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: Coeval[ApacheProducer[K, V]])(
     implicit K: Serializer[K],
     V: Serializer[V]): KafkaProducer[K, V] = {
     new Implementation[K, V](config, sc, producerRef)
   }
 
-  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: ApacheProducer[K, V])(
+  private final class Implementation[K, V](config: KafkaProducerConfig, sc: Scheduler, producerRef: Coeval[ApacheProducer[K, V]])(
     implicit K: Serializer[K],
     V: Serializer[V])
       extends KafkaProducer[K, V] with StrictLogging {
@@ -84,7 +84,7 @@ object KafkaProducer {
     private val isCanceled = Atomic(false)
 
     def underlying: Task[ApacheProducer[K, V]] =
-      Task.eval(producerRef)
+      producerRef.to[Task]
 
     def send(topic: String, value: V): Task[Option[RecordMetadata]] =
       send(new ProducerRecord[K, V](topic, value))
@@ -104,11 +104,8 @@ object KafkaProducer {
             val isActive = Atomic(true)
             val cancelable = SingleAssignCancelable()
             try {
-              // Force evaluation
-              val producer = producerRef
-
               // Using asynchronous API
-              val future = producer.send(
+              val future = producerRef.value().send(
                 record,
                 new KafkaCallback {
                   def onCompletion(meta: RecordMetadata, exception: Exception): Unit =
@@ -156,7 +153,7 @@ object KafkaProducer {
               asyncCb.onSuccess(())
             } else {
               try {
-                producerRef.close()
+                producerRef.value().close()
                 asyncCb.onSuccess(())
               } catch {
                 case NonFatal(ex) =>

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -62,7 +62,7 @@ final class KafkaProducerSink[K, V] private (
               if (parallelism == 1)
                 Task.traverse(list)(p.value().send(_))
               else {
-                Task.wanderN(parallelism)(list)(r => p.value().send(r))
+                Task.parTraverseN(parallelism)(list)(r => p.value().send(r))
               }
 
             val recovered = sendTask.redeemWith(

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -17,7 +17,6 @@
 
 package monix.kafka
 
-import cats.syntax.apply._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.kafka.config.AutoOffsetReset


### PR DESCRIPTION
Use Kafka Producer, Consumer interfaces as types where appropriate instead of using implementation types. Resolves https://github.com/monix/monix-kafka/issues/244