### PR TITLE
Enable '-Xfatal-warnings flag (#114)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,6 @@ https://github.com/AdrielVelazquez
 
 Arun Gopalpuri
 https://github.com/arun0009
+
+Pau Alarcón
+https://github.com/paualarco

--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
   licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/monix/monix-kafka")),
   headerLicense := Some(HeaderLicense.Custom(
-    """|Copyright (c) 2014-2019 by The Monix Project Developers.
+    """|Copyright (c) 2014-2021 by The Monix Project Developers.
        |
        |Licensed under the Apache License, Version 2.0 (the "License");
        |you may not use this file except in compliance with the License.
@@ -193,6 +193,7 @@ lazy val commonDependencies = Seq(
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
     "com.typesafe" % "config" % "1.4.1",
     "org.slf4j" % "log4j-over-slf4j" % "1.7.30",
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.3.2",
     // For testing ...
     "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
     "org.scalatest" %% "scalatest" % "3.0.9" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
   scalacOptions ++= Seq(
     // Turns all warnings into errors ;-)
     // TODO: enable after fixing deprecations for Scala 2.13
-//    "-Xfatal-warnings",
+    "-Xfatal-warnings",
     // Enables linter options
     "-Xlint:adapted-args", // warn if an argument list is modified to match the receiver
     "-Xlint:nullary-unit", // warn when nullary methods return Unit

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Commit.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Commit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/CommittableMessage.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/CommittableMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/CommittableOffset.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/CommittableOffset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -93,8 +93,8 @@ object CommittableOffsetBatch {
     if (committableOffsets.nonEmpty) {
       committableOffsets
         .groupBy(_.commitCallback)
-        .mapValues(CommittableOffsetBatch(_))
         .values
+        .map(CommittableOffsetBatch(_))
         .toList
     } else {
       List.empty

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** Configuration for Kafka Consumer.
@@ -287,7 +287,7 @@ final case class KafkaConsumerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -25,7 +25,8 @@ import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
-import scala.collection.JavaConverters._
+
+import scala.jdk.CollectionConverters._
 import scala.concurrent.blocking
 import scala.util.matching.Regex
 
@@ -245,7 +246,6 @@ object KafkaConsumerObservable {
     K: Deserializer[K],
     V: Deserializer[V]): Task[Consumer[K, V]] = {
 
-    import collection.JavaConverters._
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.Observer
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetCommitCallback}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -18,11 +18,11 @@ package monix.kafka
 
 import java.io.File
 import java.util.Properties
-import collection.JavaConverters._
 
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** The Kafka Producer config.
@@ -272,7 +272,7 @@ case class KafkaProducerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.kafka.config
 
 import com.typesafe.config.ConfigException.BadValue

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-0.10.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.10.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -146,7 +146,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
       val result = for {
         //Force creation of producer
         s1 <- producer.send(topicName, "test-message-1")
-        res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+        res <- Task.parZip2(producer.close(), Task.parSequence(List.fill(10)(sendTask)).attempt)
         (_, s2) = res
         s3 <- sendTask
       } yield (s1, s2, s3)

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Commit.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Commit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/CommittableMessage.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/CommittableMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/CommittableOffset.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/CommittableOffset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -93,8 +93,8 @@ object CommittableOffsetBatch {
     if (committableOffsets.nonEmpty) {
       committableOffsets
         .groupBy(_.commitCallback)
-        .mapValues(CommittableOffsetBatch(_))
         .values
+        .map(CommittableOffsetBatch(_))
         .toList
     } else {
       List.empty

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** Configuration for Kafka Consumer.
@@ -293,7 +293,7 @@ final case class KafkaConsumerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -25,7 +25,7 @@ import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.blocking
 import scala.util.matching.Regex
 
@@ -245,7 +245,6 @@ object KafkaConsumerObservable {
     K: Deserializer[K],
     V: Deserializer[V]): Task[Consumer[K, V]] = {
 
-    import collection.JavaConverters._
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.Observer
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetCommitCallback}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** The Kafka Producer config.
@@ -272,7 +272,7 @@ case class KafkaProducerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.kafka.config
 
 import com.typesafe.config.ConfigException.BadValue

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-0.11.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-0.11.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -143,7 +143,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
       val result = for {
         //Force creation of producer
         s1 <- producer.send(topicName, "test-message-1")
-        res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+        res <- Task.parZip2(producer.close(), Task.parSequence(List.fill(10)(sendTask)).attempt)
         (_, s2) = res
         s3 <- sendTask
       } yield (s1, s2, s3)

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Commit.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Commit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/CommittableMessage.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/CommittableMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/CommittableOffset.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/CommittableOffset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -93,8 +93,8 @@ object CommittableOffsetBatch {
     if (committableOffsets.nonEmpty) {
       committableOffsets
         .groupBy(_.commitCallback)
-        .mapValues(CommittableOffsetBatch(_))
         .values
+        .map(CommittableOffsetBatch(_))
         .toList
     } else {
       List.empty

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** Configuration for Kafka Consumer.
@@ -279,7 +279,7 @@ final case class KafkaConsumerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -24,6 +24,7 @@ import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.blocking
 
 /** Exposes an `Observable` that consumes a Kafka stream by
@@ -197,7 +198,6 @@ object KafkaConsumerObservable {
     K: Deserializer[K],
     V: Deserializer[V]): Task[Consumer[K, V]] = {
 
-    import collection.JavaConverters._
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.Observer
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetCommitCallback}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** The Kafka Producer config.
@@ -266,7 +266,7 @@ case class KafkaProducerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.kafka.config
 
 import com.typesafe.config.ConfigException.BadValue

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-0.9.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
+++ b/kafka-0.9.x/src/test/scala/monix/kafka/MonixKafkaTest.scala
@@ -134,7 +134,7 @@ class MonixKafkaTest extends FunSuite {
     val result = for {
       //Force creation of producer
       s1 <- producer.send(topicName, "test-message-1")
-      res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+      res <- Task.parZip2(producer.close(), Task.parSequence(List.fill(10)(sendTask)).attempt)
       (_, s2) = res
       s3 <- sendTask
     } yield (s1, s2, s3)

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Commit.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Commit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/CommittableMessage.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/CommittableMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/CommittableOffset.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/CommittableOffset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/CommittableOffsetBatch.scala
@@ -93,8 +93,8 @@ object CommittableOffsetBatch {
     if (committableOffsets.nonEmpty) {
       committableOffsets
         .groupBy(_.commitCallback)
-        .mapValues(CommittableOffsetBatch(_))
         .values
+        .map(CommittableOffsetBatch(_))
         .toList
     } else {
       List.empty

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Deserializer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** Configuration for Kafka Consumer.
@@ -300,7 +300,7 @@ final case class KafkaConsumerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -24,7 +24,7 @@ import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, KafkaConsumer}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.blocking
 import scala.util.matching.Regex
 
@@ -244,7 +244,6 @@ object KafkaConsumerObservable {
     K: Deserializer[K],
     V: Deserializer[V]): Task[Consumer[K, V]] = {
 
-    import collection.JavaConverters._
     Task.evalAsync {
       val configMap = config.toJavaMap
       blocking {

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -25,7 +25,7 @@ import monix.reactive.Observer
 import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -25,10 +25,10 @@ import monix.reactive.observers.Subscriber
 import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetCommitCallback}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{blocking, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
+import scala.jdk.CollectionConverters._
 
 /** KafkaConsumerObservable with ability to manual commit offsets
   * and forcibly disables auto commits in configuration.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerConfig.scala
@@ -19,10 +19,10 @@ package monix.kafka
 import java.io.File
 import java.util.Properties
 
-import collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
 import monix.kafka.config._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 /** The Kafka Producer config.
@@ -272,7 +272,7 @@ case class KafkaProducerConfig(
   )
 
   def toJavaMap: java.util.Map[String, Object] =
-    toMap.filter(_._2 != null).mapValues(_.asInstanceOf[AnyRef]).toMap.asJava
+    toMap.filter(_._2 != null).map{case (a, b) =>(a, b.asInstanceOf[AnyRef])}.asJava
 
   def toProperties: Properties = {
     val props = new Properties()

--- a/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/KafkaProducerSink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/Serializer.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/Acks.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ClassName.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ClassName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/CompressionType.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/CompressionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableCommitType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/ObservableSeekOnStart.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monix.kafka.config
 
 import com.typesafe.config.ConfigException.BadValue

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/PartitionerName.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/PartitionerName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/SSLProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
+++ b/kafka-1.0.x/src/main/scala/monix/kafka/config/SecurityProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
+++ b/kafka-1.0.x/src/test/scala/monix/kafka/MonixKafkaTopicListTest.scala
@@ -145,7 +145,7 @@ class MonixKafkaTopicListTest extends FunSuite with KafkaTestKit {
       val result = for {
         //Force creation of producer
         s1 <- producer.send(topicName, "test-message-1")
-        res <- Task.parZip2(producer.close(), Task.gather(List.fill(10)(sendTask)).attempt)
+        res <- Task.parZip2(producer.close(), Task.parSequence(List.fill(10)(sendTask)).attempt)
         (_, s2) = res
         s3 <- sendTask
       } yield (s1, s2, s3)


### PR DESCRIPTION
- Enable fatal warings flag
- Replaces `JavaConverters` by `CollectionConverters` from `scala.compat`
- Replaces `.mapValues` by simple `map`s
- Replaces `Task.gather` for `Task.parSequence`
- Updated year in copyright header